### PR TITLE
Travis fix - force conflict resolution (allow package downgrade)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.opensuse.org/yast/head/containers/yast-cpp:latest
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+RUN zypper --non-interactive in --force-resolution --no-recommends \
   cracklib-devel \
   perl-Digest-SHA1 \
   perl-X500-DN \


### PR DESCRIPTION
- Use `--force-resolution` to force conflict resolution (allow package downgrade)
- The `--gpg-auto-import-keys` option is not needed anymore (the needed GPG keys are already imported in the base Docker image)